### PR TITLE
Gsi projection and ttl fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ module "dynamodb" {
   init_db_aws_profile        = local.init_db_aws_profile
   init_db_env_type           = local.init_db_env_type
 
-  ttl_attribute_name         = "TTL"
-  ttl_value                  = true
+  ttl_attribute_name         = "created_at"
 
   global_secondary_indeces   = [
     {
@@ -81,7 +80,13 @@ module "dynamodb" {
   ]
 }
 ```
+## Important notes.
+By providing `ttl_attribute_name` you enabling the TTL on you dynamodb table.<br>
+FYI this option have some limitation set by AWS:<br>
+* Once you set `ttl_attribute_name` attribute you cannot immediatly change it to other value you will need to wait around one hour.
+* If you will remove `ttl_attribute_name` attribute from your `dynamodb.tf` it will not turn off the TTL on your table.
 
+For more information visit [this](https://github.com/hashicorp/terraform-provider-aws/issues/10304) opened bug.<br>
 ## Parameters
 `billing_mode = PROVISIONED | PAY_PER_REQUEST`
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,23 @@ module "dynamodb" {
       hash_key_type  = "N"
       range_key      = "TemplateId"
       range_key_type = "S"
+    },
+    {
+      name           = "CustomerId-TemplateId-index"
+      hash_key       = "CustomerId"
+      hash_key_type  = "N"
+      range_key      = "TemplateId"
+      range_key_type = "S"
+      projection_type = "KEYS_ONLY"
+    },
+    {
+      name           = "UserId-TemplateId-index"
+      hash_key       = "UserId"
+      hash_key_type  = "N"
+      range_key      = "TemplateId"
+      range_key_type = "S"
+      projection_type = "INCLUDE"
+      non_key_attributes = [ "CreateDate", "Entity" ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -50,6 +50,9 @@ module "dynamodb" {
   init_db_aws_profile        = local.init_db_aws_profile
   init_db_env_type           = local.init_db_env_type
 
+  ttl_attribute_name         = "TTL"
+  ttl_value                  = true
+
   global_secondary_indeces   = [
     {
       name           = "Entity-TemplateId-index"

--- a/examples/terraform-dynmodb/README.md
+++ b/examples/terraform-dynmodb/README.md
@@ -43,6 +43,8 @@ module "dynamodb" {
   init_db_environment        = local.init_db_environment
   init_db_aws_profile        = local.init_db_aws_profile
   init_db_env_type           = local.init_db_env_type
+  ttl_attribute_name         = "TTL"
+  ttl_value                  = true
 
   global_secondary_indeces   = [
     {

--- a/examples/terraform-dynmodb/README.md
+++ b/examples/terraform-dynmodb/README.md
@@ -43,8 +43,7 @@ module "dynamodb" {
   init_db_environment        = local.init_db_environment
   init_db_aws_profile        = local.init_db_aws_profile
   init_db_env_type           = local.init_db_env_type
-  ttl_attribute_name         = "TTL"
-  ttl_value                  = true
+  ttl_attribute_name         = "created_at"
 
   global_secondary_indeces   = [
     {

--- a/examples/terraform-dynmodb/README.md
+++ b/examples/terraform-dynmodb/README.md
@@ -51,6 +51,23 @@ module "dynamodb" {
       hash_key_type  = "N"
       range_key      = "TemplateId"
       range_key_type = "S"
+    },
+    {
+      name           = "CustomerId-TemplateId-index"
+      hash_key       = "CustomerId"
+      hash_key_type  = "N"
+      range_key      = "TemplateId"
+      range_key_type = "S"
+      projection_type = "KEYS_ONLY"
+    },
+    {
+      name           = "UserId-TemplateId-index"
+      hash_key       = "UserId"
+      hash_key_type  = "N"
+      range_key      = "TemplateId"
+      range_key_type = "S"
+      projection_type = "INCLUDE"
+      non_key_attributes = [ "CreateDate", "Entity" ]
     }
   ]
 }

--- a/main.tf
+++ b/main.tf
@@ -7,6 +7,12 @@ locals {
   # in all places, and ignore table_name variable, to avoid issues
 
   table_name = try("${var.table_name}","dynamodb-${var.app_name}-${local.env_name}")
+  ttl = (var.ttl_enable == true ? [
+  {
+    ttl_enable = var.ttl_enable
+    ttl_attribute : var.ttl_attribute_name
+  }
+] : [])
 }
 
 resource "aws_dynamodb_table" "basic-dynamodb-table" {
@@ -67,9 +73,12 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
     }
   }
   
-  ttl {
-    attribute_name = var.ttl_attribute_name
-    enabled        = var.ttl_value
+  dynamic "ttl" {
+    for_each = local.ttl
+    content {
+      enabled        = local.ttl[0].ttl_enable
+      attribute_name = local.ttl[0].ttl_attribute_name
+    }
   }
 
   tags = {

--- a/main.tf
+++ b/main.tf
@@ -7,12 +7,6 @@ locals {
   # in all places, and ignore table_name variable, to avoid issues
 
   table_name = try("${var.table_name}","dynamodb-${var.app_name}-${local.env_name}")
-  ttl = (var.ttl_enable == true ? [
-  {
-    ttl_enable = var.ttl_enable
-    ttl_attribute : var.ttl_attribute_name
-  }
-] : [])
 }
 
 resource "aws_dynamodb_table" "basic-dynamodb-table" {
@@ -74,10 +68,11 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
   }
   
   dynamic "ttl" {
-    for_each = local.ttl
+    for_each = var.ttl_attribute_name != null ? [1] : []
+    iterator = index
     content {
-      enabled        = local.ttl[0].ttl_enable
-      attribute_name = local.ttl[0].ttl_attribute_name
+      enabled        = true
+      attribute_name = var.ttl_attribute_name
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -62,7 +62,8 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
       range_key = try(index.value.range_key, null)
       read_capacity =  var.billing_mode == "PROVISIONED" ? var.read_capacity :  null
       write_capacity =  var.billing_mode == "PROVISIONED" ? var.write_capacity :  null
-      projection_type    = "ALL"
+      projection_type    = try(index.value.projection_type, "ALL")
+      non_key_attributes = try(index.value.non_key_attributes, null)
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -63,7 +63,7 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
       read_capacity =  var.billing_mode == "PROVISIONED" ? var.read_capacity :  null
       write_capacity =  var.billing_mode == "PROVISIONED" ? var.write_capacity :  null
       projection_type    = try(index.value.projection_type, "ALL")
-      non_key_attributes = try(index.value.non_key_attributes, null)
+      non_key_attributes = try(index.value.projection_type, "ALL") == "INCLUDE" ? try(index.value.non_key_attributes, null) : null
     }
   }
 

--- a/main.tf
+++ b/main.tf
@@ -65,6 +65,11 @@ resource "aws_dynamodb_table" "basic-dynamodb-table" {
       projection_type    = "ALL"
     }
   }
+  
+  ttl {
+    attribute_name = var.ttl_attribute_name
+    enabled        = var.ttl_value
+  }
 
   tags = {
     Name        = local.table_name

--- a/variables.tf
+++ b/variables.tf
@@ -108,7 +108,7 @@ variable "ttl_value" {
   description = "time to leave"
 }
 
-value "ttl_attribute_name" {
+variable "ttl_attribute_name" {
   type = string
   default = ""
 }

--- a/variables.tf
+++ b/variables.tf
@@ -110,5 +110,5 @@ variable "ttl_value" {
 
 variable "ttl_attribute_name" {
   type = string
-  default = "TimeToExist"
+  default = "created_at"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -102,13 +102,7 @@ variable "global_secondary_indeces" {
   default = []
 }
 
-variable "ttl_value" {
-  type = bool
-  default = false 
-  description = "Time to leave"
-}
-
 variable "ttl_attribute_name" {
   type = string
-  default = "created_at"
+  default = null
 }

--- a/variables.tf
+++ b/variables.tf
@@ -105,10 +105,10 @@ variable "global_secondary_indeces" {
 variable "ttl_value" {
   type = bool
   default = false 
-  description = "time to leave"
+  description = "Time to leave"
 }
 
 variable "ttl_attribute_name" {
   type = string
-  default = ""
+  default = "TimeToExist"
 }

--- a/variables.tf
+++ b/variables.tf
@@ -101,3 +101,14 @@ variable "global_secondary_indeces" {
   description = "Array of GSI definitions"
   default = []
 }
+
+variable "ttl_value" {
+  type = bool
+  default = false 
+  description = "time to leave"
+}
+
+value "ttl_attribute_name" {
+  type = string
+  default = ""
+}


### PR DESCRIPTION
This is a continuation of https://github.com/toluna-terraform/terraform-aws-dynamodb/pull/14
In this PR we implementing the TTL a bit different due to the [know bug/feature of AWS](https://github.com/hashicorp/terraform-provider-aws/issues/10304). 
When you passing `ttl_attribute_name` attribute the TTL will be enabled on your dynamodb table  otherwise it will not be crated at all.